### PR TITLE
Member block and title block fix.

### DIFF
--- a/config/install/block.block.views_block__members_block_1.yml
+++ b/config/install/block.block.views_block__members_block_1.yml
@@ -1,23 +1,33 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - views.view.members
   module:
     - context
     - islandora
+    - views
   theme:
     - york_drupal_theme
-id: york_drupal_theme_page_title
+id: views_block__members_block_1
 theme: york_drupal_theme
 region: content
-weight: -6
+weight: -1
 provider: null
-plugin: page_title_block
+plugin: 'views_block:members-block_1'
 settings:
-  id: page_title_block
-  label: 'Page title'
-  label_display: '0'
-  provider: core
+  id: 'views_block:members-block_1'
+  label: ''
+  label_display: visible
+  provider: views
+  context_mapping: {  }
+  views_label: ''
+  items_per_page: none
 visibility:
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
@@ -33,10 +43,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/install/block.block.york_drupal_theme_content.yml
+++ b/config/install/block.block.york_drupal_theme_content.yml
@@ -8,7 +8,7 @@ dependencies:
 id: york_drupal_theme_content
 theme: york_drupal_theme
 region: content
-weight: 7
+weight: -2
 provider: null
 plugin: system_main_block
 settings:

--- a/config/install/york_drupal_theme.settings.yml
+++ b/config/install/york_drupal_theme.settings.yml
@@ -1,5 +1,3 @@
-_core:
-  default_config_hash: w2HQYJGLG4-Mmk19eIIKgoXCiXEJm-NVSNhhv-VdpUI
 favicon:
   use_default: true
 features:


### PR DESCRIPTION
- Removes some filters from title (from a legacy module) that prevented the node title from being displayed.
- Adds the members block, and changes the weight of the block, so that it lower (below) than the content.
- Adjust weight of content block
- Remove config hash of theme settings.