### PR TITLE
Add language switcher block; resolves #12.

### DIFF
--- a/config/install/block.block.languageswitcher.yml
+++ b/config/install/block.block.languageswitcher.yml
@@ -1,0 +1,45 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - context
+    - islandora
+    - language
+  theme:
+    - york_drupal_theme
+id: languageswitcher
+theme: york_drupal_theme
+region: top_header_form
+weight: 0
+provider: null
+plugin: 'language_block:language_interface'
+settings:
+  id: 'language_block:language_interface'
+  label: 'Language switcher'
+  label_display: '0'
+  provider: language
+visibility:
+  user_status:
+    id: user_status
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
+    user_status:
+      viewing_profile: '0'
+      logged_viewing_profile: '0'
+      own_page_true: '0'
+      field_value: '0'
+    user_fields: uid
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
+  context:
+    id: context
+    negate: null
+    values: ''
+  media_source_mimetype:
+    id: media_source_mimetype
+    negate: false
+    context_mapping: {  }
+    mimetype: ''


### PR DESCRIPTION
How to test:
1. Vist http://localhost:8000//admin/config/development/configuration/full/import
2. Click Single item"
3. Select "Block" as a "Configuration type"
4. Paste in the following, and click "Import"

```
langcode: en
status: true
dependencies:
  module:
    - context
    - islandora
    - language
  theme:
    - york_drupal_theme
id: languageswitcher
theme: york_drupal_theme
region: top_header_form
weight: 0
provider: null
plugin: 'language_block:language_interface'
settings:
  id: 'language_block:language_interface'
  label: 'Language switcher'
  label_display: '0'
  provider: language
visibility:
  user_status:
    id: user_status
    negate: false
    context_mapping:
      user: '@user.current_user_context:current_user'
    user_status:
      viewing_profile: '0'
      logged_viewing_profile: '0'
      own_page_true: '0'
      field_value: '0'
    user_fields: uid
  context_all:
    id: context_all
    negate: null
    values: ''
  context:
    id: context
    negate: null
    values: ''
  media_source_mimetype:
    id: media_source_mimetype
    negate: false
    context_mapping: {  }
    mimetype: ''
```

Visit the home page, and you should see something like this:

![Screenshot 2023-01-26 at 07-48-18 York University Digital Library YUDL DEV](https://user-images.githubusercontent.com/218561/214839809-867f0ef9-a9f5-48f9-859e-3aee10a9614e.png)
