### PR TITLE
Flip languageswitcher and search blocks.

### DIFF
--- a/config/install/block.block.exposedformsolr_search_contentpage_1_2.yml
+++ b/config/install/block.block.exposedformsolr_search_contentpage_1_2.yml
@@ -13,7 +13,7 @@ dependencies:
 id: exposedformsolr_search_contentpage_1_2
 theme: york_drupal_theme
 region: top_header_form
-weight: -10
+weight: -9
 provider: null
 plugin: 'views_exposed_filter_block:solr_search_content-page_1'
 settings:

--- a/config/install/block.block.languageswitcher.yml
+++ b/config/install/block.block.languageswitcher.yml
@@ -10,7 +10,7 @@ dependencies:
 id: languageswitcher
 theme: york_drupal_theme
 region: top_header_form
-weight: 0
+weight: -10
 provider: null
 plugin: 'language_block:language_interface'
 settings:


### PR DESCRIPTION
Just flipping the placement of these two blocks to make things easier for when we style them.

How to test:

1. Visit http://localhost:8000/admin/structure/block
2. Move "Language switcher" above Exposed form: solr_search_content-page_1
3. Click "Save blocks"
4. Visit a non-frontpage url such as http://localhost:8000/solr-search/content?search_api_fulltext=

![Screenshot 2023-01-30 at 07-26-30 Search Results YUDL DEV](https://user-images.githubusercontent.com/218561/215477038-32527acd-214e-46cf-8c02-3ee7ac273b88.png)
