### PR TITLE
Display Openseadragon on paged content.

### DIFF
--- a/config/install/context.context.openseadragon_block.yml
+++ b/config/install/context.context.openseadragon_block.yml
@@ -1,0 +1,45 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - islandora
+    - openseadragon
+label: 'Paged Content - Openseadragon'
+name: openseadragon_block
+group: Display
+description: 'Display a block for Paged Content'
+requireAllConditions: false
+disabled: false
+conditions:
+  node_has_term:
+    id: node_has_term
+    negate: false
+    uuid: e5689bd5-7eec-4378-b329-2f35d5bb35b0
+    context_mapping:
+      node: '@node.node_route_context:node'
+    uri: 'https://schema.org/Book,https://schema.org/PublicationIssue'
+    logic: or
+reactions:
+  blocks:
+    id: blocks
+    uuid: 50b9b25e-0836-4531-8a78-9698d71d81de
+    blocks:
+      d19bb20b-6aa3-477a-b717-a282ac57918c:
+        uuid: d19bb20b-6aa3-477a-b717-a282ac57918c
+        id: openseadragon_block
+        label: 'Openseadragon block'
+        provider: openseadragon
+        label_display: '0'
+        region: content
+        weight: '-2'
+        custom_id: openseadragon_block
+        theme: york_drupal_theme
+        css_class: ''
+        unique: 0
+        context_id: openseadragon_block
+        context_mapping: {  }
+        iiif_manifest_url: 'node/[node:nid]/book-manifest'
+        third_party_settings: {  }
+    include_default_blocks: 1
+    saved: false
+weight: -1


### PR DESCRIPTION
![Peek 2023-01-31 13-33](https://user-images.githubusercontent.com/218561/215851120-03225eea-a0d2-4ef5-b098-509033819dc5.gif)

This is tied to two other PRs, and all three of these need to be pulled in together:
 - https://github.com/yorkulibraries/yudl_defaults/pull/38
 - https://github.com/yorkulibraries/yudl-playbook/pull/54

1. We need to set some specific OpenSeadragon settings in the build, these can be configured locally instead of rebuilding at http://localhost:8000/admin/config/media/openseadragon
![Screenshot from 2023-01-31 13-37-47](https://user-images.githubusercontent.com/218561/215852172-7def2d8c-c3d1-4fed-b596-20f40802ed2b.png)
2. The context can be loaded by pulling it down and putting it in a directory somewhere on the vagrant instance and running: `drush cim -y --partial --source=/tmp/test && drush cr` from `/var/www/html/drupal`
3. https://github.com/yorkulibraries/yudl_defaults/pull/38 just cleans up some related but unneeded configurations.
 

