### PR TITLE
Add map block to "Explore Locations" page.

### DIFF
--- a/config/install/block.block.views_block__map_block_1.yml
+++ b/config/install/block.block.views_block__map_block_1.yml
@@ -1,0 +1,54 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.map
+  module:
+    - context
+    - islandora
+    - system
+    - views
+  theme:
+    - york_drupal_theme
+id: views_block__map_block_1
+theme: york_drupal_theme
+region: content
+weight: -9
+provider: null
+plugin: 'views_block:map-block_1'
+settings:
+  id: 'views_block:map-block_1'
+  label: ''
+  label_display: '0'
+  provider: views
+  views_label: ''
+  items_per_page: none
+visibility:
+  user_status:
+    id: user_status
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
+    user_status:
+      viewing_profile: '0'
+      logged_viewing_profile: '0'
+      own_page_true: '0'
+      field_value: '0'
+    user_fields: uid
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
+  context:
+    id: context
+    negate: null
+    values: ''
+  media_source_mimetype:
+    id: media_source_mimetype
+    negate: false
+    context_mapping: {  }
+    mimetype: ''
+  request_path:
+    id: request_path
+    negate: false
+    pages: /explore/locations


### PR DESCRIPTION
- partially addresses #28

How to test:

- Put `config/install/block.block.views_block__map_block_1.yml` and `yudl_defaults/config/install/views.view.map.yml` in a directory (`/tmp/issue-28-test`)
- `cd /var/www/html/drupal`
- `drush cim -y --partial --source=/tmp/issue-28-test`
- Visit http://localhost:8000/explore/locations

![Screenshot 2023-02-12 at 19-38-00 Explore Locations YUDL DEV](https://user-images.githubusercontent.com/218561/218347146-deef70a4-2f40-4da9-bdcc-69d8b3514c5c.png)

^^ That's with a few coordinates added to get the initial placement of the map setup right.

![Screenshot 2023-02-12 at 19-08-02 Explore Locations YUDL DEV](https://user-images.githubusercontent.com/218561/218347215-eee810c8-ffbd-4e92-ad86-a46195854b47.png)

^^
If you're just doing the sample objects it'll look like this