### PR TITLE
Add stying-theme to Featured Collections on Homepage node-1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -97,7 +97,7 @@ td {
     font-weight: bold;
 }
 
-/** BOOTSTRAP 5 Styles Override **/
+/** BOOTSTRAP 5 OVERRIDE & CUSTOM STYLES **/
 
 .featured-collections .card-img-top {
   width: 100%;
@@ -107,4 +107,50 @@ td {
 
 .featured-collections .card-title {
   font-weight: 500;
+}
+
+.highlighted #views-exposed-form-solr-search-content-page-1 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.search{
+  position: relative;
+  box-shadow: 0 0 40px rgba(51, 51, 51, .1);
+}
+
+.search input[type="text"] {
+  text-indent: 25px;
+  /* border: 2px solid #d6d4d4; */
+  border: 2px solid #d6cfca;
+  height: 50px;
+}
+
+.search input:focus{
+  box-shadow: none;
+  /* border: 2px solid #E31837; */
+  border: 2px solid #b7aea9;
+}
+
+.search .fa-search, .search .fa-magnifying-glass {
+  position: absolute;
+  top: 18px;
+  left: 16px;
+}
+
+.search button {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  height: 40px;
+  width: 110px;
+}
+
+/* For mobile: */
+@media only screen and (max-width: 500px) {
+  .search input::placeholder {
+    color: transparent;
+  }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -96,3 +96,15 @@ td {
 .sidebar h2 {
     font-weight: bold;
 }
+
+/** BOOTSTRAP 5 Styles Override **/
+
+.featured-collections .card-img-top {
+  width: 100%;
+  height: 20vh;
+  object-fit: cover;
+}
+
+.featured-collections .card-title {
+  font-weight: 500;
+}

--- a/template/page--node--1.html.twig
+++ b/template/page--node--1.html.twig
@@ -154,6 +154,111 @@
 								<a id="main-content" tabindex="-1"></a>
 								{{ page.content }}
 							</section>
+							<section class="section featured-collections my-4 bg-light p-3 rounded">
+								<h2 class="display-6 border-bottom border-danger mb-4">Featured Collections</h2>
+								<div class="row row-cols-1 row-cols-md-3 row-cols-lg-4 g-4">
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/101"><img src="/{{ directory }}/images/featured-collection-ntree.jpg" class="card-img-top" alt="National Round Table for the Environment and the Economy Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">National Round Table for the Environment and the Economy</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/10"><img src="/{{ directory }}/images/featured-collection-ocf.jpg" class="card-img-top" alt="Ojibwe Cultural Foundation Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Ojibwe Cultural Foundation</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/11"><img src="/{{ directory }}/images/featured-collection-rare-classic-chinese-literature.jpg" class="card-img-top" alt="Rare classic Chinese literature Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Rare classic Chinese literature</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/48"><img src="/{{ directory }}/images/featured-collection-toronto-telegram.jpg" class="card-img-top" alt="Toronto Telegram Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Toronto Telegram</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/14"><img src="/{{ directory }}/images/featured-collection-yolton.jpg" class="card-img-top" alt="Yolton Library Rare Book Collection Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Yolton Library Rare Book Collection</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/28"><img src="/{{ directory }}/images/featured-collection-york-photographs.jpg" class="card-img-top" alt="York University Photograph collection Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">York University Photograph collection</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/88"><img src="/{{ directory }}/images/featured-collection-historical-maps.jpg" class="card-img-top" alt="Historical Map Collections Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Historical Map Collections</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/106"><img src="/{{ directory }}/images/featured-collection-golha.jpg" class="card-img-top" alt="The Golha Programmes Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">The Golha Programmes</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/86"><img src="/{{ directory }}/images/featured-collection-home-made-visible.jpg" class="card-img-top" alt="Home Made Visible collection Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Home Made Visible collection</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/61"><img src="/{{ directory }}/images/featured-collection-jean.jpg" class="card-img-top" alt="Jean Augustine fonds Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Jean Augustine fonds</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/119"><img src="/{{ directory }}/images/featured-collection-kenneth-shah.jpg" class="card-img-top" alt="Kenneth Shah fonds Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Kenneth Shah fonds</h5>
+											</div>
+										</div>
+									</div>
+									<div class="col">
+										<div class="card h-100">
+											<a href="/node/59"><img src="/{{ directory }}/images/featured-collection-mariposa-folk-foundation.jpg" class="card-img-top" alt="Mariposa Folk Foundation fonds Image"></a>
+											<div class="card-body">
+												<h5 class="card-title">Mariposa Folk Foundation fonds</h5>
+											</div>
+										</div>
+									</div>
+								</div>
+
+								<div class="d-grid gap-2 my-4">
+									<a class="btn btn-primary btn-lg" aria-current="page" href="/explore/collections">Explore more collections</a>
+								</div>
+							</section>
 						</main>
 						{% if page.sidebar_first %}
 							<div{{sidebar_first_attributes}}>

--- a/template/views-exposed-form--solr-search-content.html.twig
+++ b/template/views-exposed-form--solr-search-content.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Theme override for a views exposed form.
+ *
+ * Available variables:
+ * - form: A render element representing the form.
+ *
+ * @see template_preprocess_views_exposed_form()
+ */
+#}
+{% if q is not empty %}
+  {#
+    This ensures that, if clean URLs are off, the 'q' is added first,
+    as a hidden form element, so that it shows up first in the POST URL.
+  #}
+{{ q }}
+{% endif %}
+<div class="row">
+  <div class="col">
+    <div class="search">
+      <i class="fa-solid fa-magnifying-glass"></i>
+      {{ form.search_api_fulltext }}
+      {{ form|without('search_api_fulltext')}}
+    </div>
+  </div>
+</div>

--- a/york_drupal_theme.theme
+++ b/york_drupal_theme.theme
@@ -32,3 +32,27 @@ function york_drupal_theme_form_system_theme_settings_alter(&$form, FormStateInt
     'bg-transparent' => t('Transparent'),
   ];
 }
+
+/**
+  * Implements hook_form_FORM_ID_alter().
+  * function york_drupal_theme_form_views_exposed_form_alter(&$form, &$form_state) {
+  * Targeted Form: views-exposed-form-solr-search-content-page-1
+  */
+
+function york_drupal_theme_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  if ($form['#id'] == 'views-exposed-form-solr-search-content-page-1') {
+
+    if (isset($form['search_api_fulltext']) && $form['search_api_fulltext']['#type'] == 'textfield') {
+      $form['search_api_fulltext'] = array(
+        '#type' => 'textfield',
+        // This is the placeholder, the text inside the textfield.
+        '#attributes' => array(
+          'placeholder' => t('Search York University Digital Library')
+          // 'class' => array('form-control form-control-lg rounded-0 ')
+        ),
+      );
+      $form['actions']['submit']['#attributes']['class'][] = 'btn-primary';
+    }
+  }
+}


### PR DESCRIPTION
Hi, 

Here is styling for the static homepage featured collections. We can always toggle the background to white or light gray,  also can change 4 columns to 3 columns just be changing BS Css to "row-cols-lg-3". 

Search box to ticket to follow this request.

Side-note: Mobile layout right side is against the wall. I did not want to touch the homepage/main structure html/css. Just focused on featured collections homepage boxes as per ticket.

<br/>


<img width="1101" alt="Screen Shot 2023-02-15 at 3 59 37 PM" src="https://user-images.githubusercontent.com/4741591/219159653-2fe341ab-1f35-4f8e-bc07-5b4c354a603b.png">

Mobile Future Issue to fix.
<img width="461" alt="Screen Shot 2023-02-15 at 4 08 45 PM" src="https://user-images.githubusercontent.com/4741591/219163438-728570e6-8eb4-4949-9517-ce9e57c917aa.png">

