### PR TITLE
Add styling for Collections info block and missing BS5 text css

### DIFF
--- a/css/colors.css
+++ b/css/colors.css
@@ -1,5 +1,20 @@
 /* ---------- Color Module Styles ----------- */
 
+/* YorkU Colors 2022-2023 
+ ** PRIMARY  
+ * #e31837  Red 
+ * #000     black
+ * #fff     white
+ ** SECONDARY 
+ * #af0d1a  Med Red 
+ * #810001  Dark Red
+ * #e1dfdc  light grey
+ * #D6CFCA; Pewter
+ * #B7AEA9; Med Grey 
+ * #686260  Dark Grey 
+ * #3AC2ED Bright blue
+ * #ACe6F8 Light Blue
+*/ 
 
 #page,
 #main-wrapper,
@@ -142,3 +157,7 @@ a:active,
   display: inline-block;
   width: auto;
 }
+
+.text-primary { color: #E31837 !important;}
+.text-secondary { color: #686260 !important;}
+.text-info { color: #3AC2ED !important; }

--- a/css/style.css
+++ b/css/style.css
@@ -117,7 +117,7 @@ td {
   height: 50px;
 }
 
-.search input:focus{
+.search input:focus {
   box-shadow: none;
   /* border: 2px solid #E31837; */
   border: 2px solid #b7aea9;
@@ -210,4 +210,66 @@ details.horizontal-tabs-pane .row:nth-child(2n),
     /* min-width: 680px; */
     height: 400px;
   }
+}
+
+/* Collections Stats box */ 
+#block-yudl-collection-info-block {
+  margin-top: 2%;
+  margin-bottom: 2%;
+}
+#block-yudl-collection-info-block > h2:first-child, 
+#block-yudl-collection-info-block #block-views-block-collection-search-block-1 > h2:first-child {
+  background: #e1dfdc; /* Light Warm Grey */
+  color: #686260;
+  padding: 10px;
+  margin-top: 10px;
+  margin-bottom: 10px; 
+  border-radius: 5px;
+  border-color: #000;
+}
+
+.card-stats .card-body {
+  padding: 1rem 1.5rem;
+}
+
+.card-stats .icon {
+  width: 3.5rem;
+  height: 3.5rem;
+}
+
+.card-stats .icon i {
+  font-size: 2.25rem;
+}
+
+.card-stats .icon-shape {
+  display: inline-flex;
+  padding: 12px;
+  text-align: center;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  background: #e1dfdc;
+  color: #686260; 
+}
+
+.card-stats .icon-shape i {
+  font-size: 1.25rem;
+}
+
+/* Collectio Search Box */
+#views-exposed-form-collection-search-block-1 {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+.form-item-collection-search #edit-collection-search {
+  border-radius: 0;
+  padding: 10px;
+}
+#views-exposed-form-collection-search-block-1 #edit-submit-collection-search {
+  border-radius: 0;
+  padding: 10px;
+}
+#views-exposed-form-collection-search-block-1 input:focus {
+  border-color: #E31837;
+  box-shadow: 0 0 .25rem rgba(227,24,25,.25);
 }


### PR DESCRIPTION
Hi,

Yudl_Customization pull request will have the structure, York Drupal Theme pull request has the css for it.
In regards to #62 

Once both are merged, collections details / info box and collection search box will look like so.

**BEFORE**
---
<img width="1356" alt="islandora-collection-details-before" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/47f5503f-f13b-46b7-b718-efc18a7b5173">

**AFTER**
---
<img width="1505" alt="islandora-collection-details-after" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/07cf63cb-ae81-4614-85a4-af4ce4a8cd83">


