### PR TITLE
Issue 63 & 73

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -299,8 +299,6 @@ details.horizontal-tabs-pane .row:nth-child(2n),
     border-radius: 10px;
   }
 }
-
-
 .copy_right{
   height: 46px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -276,3 +276,18 @@ details.horizontal-tabs-pane .row:nth-child(2n),
 .copy_right{
   height: 46px;
 }
+
+/* Collection Info Block Pagination */
+.block-yudl-collection-info-block nav .pagination { 
+  justify-content: center; /* Center the Pager */
+}
+.block-yudl-collection-info-block nav .pagination li {
+  margin-bottom: 10px;
+}
+/* Mobile */
+@media only screen and (max-width: 500px) {
+  .block-yudl-collection-info-block nav .pagination {
+    flex-wrap: wrap; /* To avoid pagination running off the screen */
+  }
+}
+

--- a/css/style.css
+++ b/css/style.css
@@ -259,20 +259,48 @@ details.horizontal-tabs-pane .row:nth-child(2n),
 /* Collectio Search Box */
 #views-exposed-form-collection-search-block-1 {
   padding-top: 10px;
-  padding-bottom: 10px;
+  padding-bottom: 15px;
 }
-.form-item-collection-search #edit-collection-search {
-  border-radius: 0;
-  padding: 10px;
+#edit-collection-search {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  padding: 12px;
+  border-width: 2px 0px 2px 2px;
+  border-color: #d6cfca;
 }
-#views-exposed-form-collection-search-block-1 #edit-submit-collection-search {
-  border-radius: 0;
-  padding: 10px;
+#edit-submit-collection-search {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  padding: 12px;
+  min-width: 110px;
+  border-width: 2px 2px 2px 0px;
+  border-color: #E31837;
 }
+
 #views-exposed-form-collection-search-block-1 input:focus {
   border-color: #E31837;
   box-shadow: 0 0 .25rem rgba(227,24,25,.25);
 }
+.form-item-collection-search input:focus {
+  box-shadow: none;
+  border: 2px solid #b7aea9;
+}
+/* Mobile */
+@media only screen and (max-width: 500px) {
+  #views-exposed-form-collection-search-block-1 .form-actions {
+    width:80%;
+  }
+  #edit-collection-search {
+    border-width: 2px;
+  }
+  #edit-submit-collection-search {
+    width: 100%;
+    border-width:2px;
+    border-radius: 10px;
+  }
+}
+
+
 .copy_right{
   height: 46px;
 }


### PR DESCRIPTION
This works on issues #63 and #73 in regards to collection search box styling and centring pagination on collection search. I could not reproduce pagination on my local, therefore used ticket's example from gamma server and incorporated css done via inspector. If you can build and local box with Lou Wise fonds that contain many records and let me know if pagination is centre or not?

## **BEFORE**:
<img width="807" alt="Screen Shot 2023-05-31 at 3 11 52 PM" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/e09e13a4-d8e6-4880-b0b4-a0bc1f9d40c7">

## **AFTER**:
<img width="590" alt="Screen Shot 2023-05-31 at 3 12 02 PM" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/3596b8ac-dc00-4a77-9852-08f29a24c4da">


## **PAGINATION CENTRED AND MOBILE FRIENDLY.**
<img width="1394" alt="Screen Shot 2023-05-31 at 3 23 39 PM" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/289d0e91-a832-4116-98eb-ee907cd0cf0d">
<img width="503" alt="Screen Shot 2023-05-31 at 3 23 47 PM" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/36c40512-9614-4efe-b3bf-56e8e78156b2">
