### PR TITLE
Remove border from collection item, Add to header only

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -303,6 +303,18 @@ details.horizontal-tabs-pane .row:nth-child(2n),
   height: 46px;
 }
 
+/* Collection Search Results -- Box Removal */
+.node--view-mode-collection-search {
+  padding: 5px;
+}
+.node--view-mode-collection-search .horizontal-tabs {
+  border: none;
+}
+.node--view-mode-collection-search header {
+  padding-bottom: 10px;
+  border-bottom: 2px solid #ccc;
+}
+
 /* Collection Info Block Pagination */
 .block-yudl-collection-info-block nav .pagination { 
   justify-content: center; /* Center the Pager */


### PR DESCRIPTION
This is remove border from collection search results item box. Just removing the border created an issue for results without pictures being squishy. Added border to header with padding for cleaner look.

### Items with images
<img width="938" alt="Screen Shot 2023-08-17 at 12 26 48 PM" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/527c7d19-3e43-4290-a4c7-585224e0dd48">

### Items without thumbnails

<img width="1143" alt="Screen Shot 2023-08-17 at 12 27 05 PM" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/05ce2b44-145b-4f67-b49d-0b1778c8b3f2">
