### PR TITLE
Add Styling for Taxonomy Metadata

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -367,3 +367,6 @@ div[property="dcterms:description"]:only-of-type {
   padding-top: 20px;
   font-size: 1.25rem
 }
+
+/* Hide the label in Taxonomy List. See twig template taxonomy-term.html.twig */
+.taxonomy-data .field__label { display: none; }

--- a/template/taxonomy-term.html.twig
+++ b/template/taxonomy-term.html.twig
@@ -33,5 +33,27 @@
     </h2>
     {% endif %}
   {{ title_suffix }}
-  {{ content }}
+  {# {{ content }} #}
+  <div class="container mt-4 mb-4">
+    <div class='taxonomy-data p-2'>
+      {% for fieldName, fieldData in content %}
+      {# <h5>{{fieldName}}</h5> #}
+      {# <p>{{ dump(fieldData)}}</p> #}
+        {% if fieldData['#title'] is not empty %}
+          {% if fieldName == 'description' %}
+            <div class='row border-bottom pt-2'>
+              <div class='col-md-3 fw-bold'>{{fieldData['#title']}}</div>
+              <div class='col-md-9'>{{ fieldData|without('#title') }}</div>
+            </div>
+          {% elseif fieldName starts with 'field_' %}
+              <div class='row border-bottom p-2'>
+                <div class='col-md-3 fw-bold'>{{fieldData['#title']}}</div>
+                <div class='col-md-9'>{{ fieldData|without('#title') }}</div>
+              </div>
+          {% endif %}
+        {% endif %} {# if data #}
+      {% endfor %}
+    </div>
+    
+  </div>
 </div>


### PR DESCRIPTION
Hi Nick, 
Please review. I tested on some random taxonomy items. Is this as expected?

### Taxonomy Collection
---
<img width="1170" alt="Taxonomy-Collection-meta" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/8c5d031e-1f5e-473d-a884-85b274384ee6">

### Copyright 1 & 2 
---
<img width="1354" alt="Taxonomy-Copyright" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/8bedb3a1-8371-4b66-bb2a-e025e447dcb9">
<img width="1236" alt="Taxonomy-Copyright-2" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/bf310b1f-65bb-4388-887c-9f1e2c3c4385">

### Map Data 
---
<img width="1290" alt="Taxonomy-Map-data" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/aaa3d2a9-355b-475c-b729-380803774c56">

### MOBILE/RESPONSIVE 
---
<img width="335" alt="Taxonomy-Mobile-view" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/b4607677-4b00-4466-826a-e98d62b1bc69">

###  Report Taxonomy
---
<img width="758" alt="Taxonomy-Reports" src="https://github.com/yorkulibraries/york_drupal_theme/assets/4741591/26123aa8-e9aa-481d-b9ab-504f4939f47e">
